### PR TITLE
Error when destroying a record with has_one association

### DIFF
--- a/lib/record_cache/datastore/active_record_31.rb
+++ b/lib/record_cache/datastore/active_record_31.rb
@@ -351,7 +351,7 @@ module RecordCache
         def delete_with_record_cache(method = options[:dependent])
           # invalidate :id cache for all record
           if load_target
-            target.class.record_cache.invalidate(record.id) if target.class.record_cache? unless target.new_record?
+            target.class.record_cache.invalidate(target.id) if target.class.record_cache? unless target.new_record?
           end
           # invalidate the referenced class for the attribute/value pair on the index cache
           @reflection.klass.record_cache.invalidate(@reflection.foreign_key.to_sym, @owner.id) if @reflection.klass.record_cache?


### PR DESCRIPTION
I got this error when trying to destroy the record:

undefined local variable or method `record' for #ActiveRecord::Associations::HasOneAssociation:0x00000008b51b18

Looks like there's a typo to load the target. Works fine after the fix.

Thanks for this great gem!
