### PR TITLE
Correctly handle parameterized find_by_sql selects

### DIFF
--- a/lib/record_cache/datastore/active_record_31.rb
+++ b/lib/record_cache/datastore/active_record_31.rb
@@ -32,10 +32,9 @@ module RecordCache
           arel = args[0]
           arel = arel.instance_variable_get(:@arel) if arel.is_a?(String)
 
-          query = arel ? RecordCache::Arel::QueryVisitor.new(args[1]).accept(arel.ast) : nil
+          query = arel && arel.respond_to?(:ast) ? RecordCache::Arel::QueryVisitor.new(args[1]).accept(arel.ast) : nil
           cacheable = query && record_cache.cacheable?(query)
-          # log only in debug mode!
-          RecordCache::Base.logger.debug{ "#{cacheable ? 'Fetch from cache' : 'Not cacheable'} (#{query}): SQL = #{arel.to_sql}" }
+
           # retrieve the records from cache if the query is cacheable otherwise go straight to the DB
           cacheable ? record_cache.fetch(query) : find_by_sql_without_record_cache(*args)
         end

--- a/spec/lib/datastore/active_record_31_spec.rb
+++ b/spec/lib/datastore/active_record_31_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe RecordCache::ActiveRecord do
+
+  it "paramterized find_by_sql should work" do
+    Apple.find_by_sql("select * from apples where id = 1").should == [Apple.find(1)]
+    Apple.find_by_sql(["select * from apples where id = ?", 2]).should == [Apple.find(2)]
+  end
+
+end


### PR DESCRIPTION
Parameterzied find_by_sql selects were erroring e.g:
User.find_by_sql(["select \* from users where login = ?",'josh'])
