### PR TITLE
Handle version == 0

### DIFF
--- a/lib/record_cache/version_store.rb
+++ b/lib/record_cache/version_store.rb
@@ -38,7 +38,7 @@ module RecordCache
       new_version = (Time.current.to_f * 10000).to_i
       version = @store.increment(key, 1, :initial => new_version)
       # renew key in case the version store already purged the key
-      if version.nil? || version == 1
+      if version.nil? || version <= 1
         version = renew(key)
       elsif version == new_version
         # only log statement in case the :initial option was supported by the cache store


### PR DESCRIPTION
When updating an ActiveRecord object that isn't currently in cache, the current version was set to 0. We want to renew in this case.
