### PR TITLE
Stop using prepared statements

### DIFF
--- a/lib/record_cache/datastore/active_record_31.rb
+++ b/lib/record_cache/datastore/active_record_31.rb
@@ -239,6 +239,7 @@ module RecordCache
         o
       end
       alias :visit_Arel_Nodes_SqlLiteral :visit_Object
+      alias :visit_Arel_Nodes_BindParam     :visit_Object
       alias :visit_Arel_SqlLiteral :visit_Object # This is deprecated
       alias :visit_String :visit_Object
       alias :visit_NilClass :visit_Object


### PR DESCRIPTION
Certain queries were being sent as prepared statements, even when disabled in rails.
pgBouncer and other external connection pool managers don't deal well with prepared statements.
I'm unsure what other side effects this change may have.

Also see:

https://github.com/orslumen/record-cache/issues/21
https://github.com/rails/rails/pull/5872
