### PR TITLE
Adds an optional TTL to limit cache time

### DIFF
--- a/lib/record_cache/strategy/base.rb
+++ b/lib/record_cache/strategy/base.rb
@@ -12,6 +12,7 @@ module RecordCache
         @attribute = attribute
         @record_store = record_store
         @cache_key_prefix = "rc/#{options[:key] || @base.name}/"
+        @ttl = options[:ttl]
       end
       
       # Retrieve the +attribute+ for this strategy (unique per model).

--- a/lib/record_cache/strategy/unique_index_cache.rb
+++ b/lib/record_cache/strategy/unique_index_cache.rb
@@ -99,13 +99,17 @@ module RecordCache
             unless versioned_key
               # renew the key in the version store in case it was missing
               key = id_to_key_map[record.send(@attribute)]
-              versioned_key = versioned_key(key, version_store.renew(key))
+              versioned_key = versioned_key(key, version_store.renew(key, version_opts))
             end
             # store the record based on the versioned key
             record_store.write(versioned_key, Util.serialize(record))
           end
           records
         end
+      end
+
+      def version_opts
+        {:ttl => @ttl}
       end
   
       # ------------------------- Utility methods ----------------------------

--- a/lib/record_cache/test/resettable_version_store.rb
+++ b/lib/record_cache/test/resettable_version_store.rb
@@ -26,9 +26,9 @@ module RecordCache
           increment_without_reset(key)
         end
         
-        def renew_with_reset(key)
+        def renew_with_reset(key, opts = {})
           updated_version_keys << key
-          renew_without_reset(key)
+          renew_without_reset(key, opts)
         end
 
         def reset!

--- a/lib/record_cache/version_store.rb
+++ b/lib/record_cache/version_store.rb
@@ -26,10 +26,11 @@ module RecordCache
 
     # In case the version store did not have a key anymore, call this methods
     # to reset the key with a (unique) new version
-    def renew(key)
+    def renew(key, options = {})
       new_version = (Time.current.to_f * 10000).to_i
-      @store.write(key, new_version, :raw => true)
-      RecordCache::Base.logger.debug{ "Version Store: renew #{key}: nil => #{new_version}" }
+      options[:ttl] += (rand(options[:ttl] / 2) * [1, -1].random) if options[:ttl]
+      @store.write(key, new_version, {:raw => true, :expires_in => options[:ttl]})
+      RecordCache::Base.logger.debug("Version Store: renew #{key}: nil => #{new_version}") if RecordCache::Base.logger.debug?
       new_version
     end
 


### PR DESCRIPTION
We have external services that update cached models without going through rails (not a recommended design), and found that the best way to avoid serving cached results from record-cache was to add a TTL to these models, so the data would expire after a set time.

The TTL parameter is optional, and has some jitter built in to help prevent records from leaving cache at the same time. The syntax for using it is like so:

cache_records :store => :shared, :unique_index => :login, :ttl => 300
