### PR TITLE
Disables writes to the cache during a transaction

### DIFF
--- a/lib/record_cache/base.rb
+++ b/lib/record_cache/base.rb
@@ -83,6 +83,12 @@ module RecordCache
         @status ||= RecordCache::ENABLED
       end
 
+      # Returns true if it safe to write to cache
+      # Shouldn't write to cache during a transaction; we leave stale data when the transaction rolls back
+      def cache_writeable?
+        ::ActiveRecord::Base.connection.open_transactions == 0
+      end
+
       # execute block of code without using the records cache to fetch records
       # note that updates are still written to the cache, as otherwise other
       # workers may receive stale results.

--- a/lib/record_cache/strategy/index_cache.rb
+++ b/lib/record_cache/strategy/index_cache.rb
@@ -93,7 +93,9 @@ module RecordCache
           # go straight to SQL result for optimal performance
           sql = @base.select('id').where(@attribute => value).to_sql
           ids = []; @base.connection.execute(sql).each{ |row| ids << (row.is_a?(Hash) ? row['id'] : row.first).to_i }
-          record_store.write(versioned_key, ids)
+          if RecordCache::Base.cache_writeable?
+            record_store.write(versioned_key, ids)
+          end
           ids
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,7 @@ RSpec.configure do |config|
   config.mock_with :rr
   
   config.before(:each) do
+    stub(RecordCache::Base).cache_writeable? {true}
     RecordCache::Base.enable
     DatabaseCleaner.start
   end


### PR DESCRIPTION
In application code, ActiveRecord can create a record during a transaction.

If we allow record-cache to write this record into the cache, and the transaction is rolledback, future select queries can return a record from cache that doesn't exist in the database. This gave us some problems, especially when running our own test suite.

This pull request prevents the above from happening, but is completely untested on system setups other than what we use for twitch.tv, and has the potential to be dangerous.

cache_writeable? is stubbed to return true for the record-cache test suite because rspec runs tests in transactions by default, and the tests are written with the assumption that things will go into cache during the tests.
