### PR TITLE
Issue #39: Fixing specs in dev environment

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+ENV["RAILS_ENV"]="test"
+
 dir = File.dirname(__FILE__)
 $LOAD_PATH.unshift dir + "/../lib"
 $LOAD_PATH.unshift dir
@@ -39,7 +41,7 @@ RSpec.configure do |config|
     RecordCache::Base.enable
     DatabaseCleaner.start
   end
-  
+
   config.after(:each) do
     DatabaseCleaner.clean
     RecordCache::Base.version_store.reset!


### PR DESCRIPTION
Fixing #39 The problem is that [the tests bump the allowable transaction count by 1](https://github.com/orslumen/record-cache/blob/master/lib/record_cache/datastore/active_record_32.rb#L18) to support database cleaner running with the default transaction strategy. Obviously this makes all tests fail in dev. Updating the spec_helper to set the env to test, since typically the spec/unit helpers in rails projects will set it to test also. 