### PR TITLE
Uses the public #select_all instead of private #select

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,5 @@ gemfile:
   - gemfiles/rails_40.gemfile
   - gemfiles/rails_41.gemfile
 
+before_install: 'gem install bundler'
 script: 'bundle exec rake'

--- a/gemfiles/rails_30.gemfile.lock
+++ b/gemfiles/rails_30.gemfile.lock
@@ -55,7 +55,7 @@ GEM
       treetop (~> 1.4.8)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mysql2 (0.4.1)
+    mysql2 (0.4.3)
     polyglot (0.3.5)
     pry (0.10.2)
       coderay (~> 1.1.0)

--- a/gemfiles/rails_31.gemfile.lock
+++ b/gemfiles/rails_31.gemfile.lock
@@ -56,7 +56,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     multi_json (1.11.2)
-    mysql2 (0.4.1)
+    mysql2 (0.4.3)
     polyglot (0.3.5)
     pry (0.10.2)
       coderay (~> 1.1.0)

--- a/gemfiles/rails_32.gemfile.lock
+++ b/gemfiles/rails_32.gemfile.lock
@@ -55,7 +55,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     multi_json (1.11.2)
-    mysql2 (0.4.1)
+    mysql2 (0.4.3)
     polyglot (0.3.5)
     pry (0.10.2)
       coderay (~> 1.1.0)

--- a/gemfiles/rails_40.gemfile.lock
+++ b/gemfiles/rails_40.gemfile.lock
@@ -50,7 +50,7 @@ GEM
     mime-types (2.6.2)
     minitest (4.7.5)
     multi_json (1.11.2)
-    mysql2 (0.4.1)
+    mysql2 (0.4.3)
     pry (0.10.2)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)

--- a/gemfiles/rails_41.gemfile.lock
+++ b/gemfiles/rails_41.gemfile.lock
@@ -51,7 +51,7 @@ GEM
     method_source (0.8.2)
     mime-types (2.6.2)
     minitest (5.8.1)
-    mysql2 (0.4.1)
+    mysql2 (0.4.3)
     pry (0.10.2)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)

--- a/lib/record_cache/datastore/active_record_30.rb
+++ b/lib/record_cache/datastore/active_record_30.rb
@@ -32,9 +32,8 @@ module RecordCache
           arel = sql.instance_variable_get(:@arel)
           sanitized_sql = sanitize_sql(sql)
 
-          records = if connection.instance_variable_get(:@query_cache_enabled)
-                      query_cache = connection.instance_variable_get(:@query_cache)
-                      query_cache["rc/#{sanitized_sql}"] ||= try_record_cache(sanitized_sql, arel)
+          records = if connection.query_cache_enabled
+                      connection.query_cache["rc/#{sanitized_sql}"] ||= try_record_cache(sanitized_sql, arel)
                     elsif connection.open_transactions > RC_TRANSACTIONS_THRESHOLD
                       connection.send(:select, sanitized_sql, "#{name} Load")
                     else

--- a/lib/record_cache/datastore/active_record_30.rb
+++ b/lib/record_cache/datastore/active_record_30.rb
@@ -35,7 +35,7 @@ module RecordCache
           records = if connection.query_cache_enabled
                       connection.query_cache["rc/#{sanitized_sql}"] ||= try_record_cache(sanitized_sql, arel)
                     elsif connection.open_transactions > RC_TRANSACTIONS_THRESHOLD
-                      connection.send(:select, sanitized_sql, "#{name} Load")
+                      connection.select_all(sanitized_sql, "#{name} Load")
                     else
                       try_record_cache(sanitized_sql, arel)
                     end
@@ -46,7 +46,7 @@ module RecordCache
         def try_record_cache(sql, arel)
           query = arel && arel.respond_to?(:ast) ? RecordCache::Arel::QueryVisitor.new.accept(arel.ast) : nil
           record_cache.fetch(query) do
-            connection.send(:select, sql, "#{name} Load")
+            connection.select_all(sql, "#{name} Load")
           end
         end
 

--- a/lib/record_cache/datastore/active_record_31.rb
+++ b/lib/record_cache/datastore/active_record_31.rb
@@ -35,9 +35,8 @@ module RecordCache
           sanitized_sql = sanitize_sql(sql)
           sanitized_sql = connection.visitor.accept(sanitized_sql.ast) if sanitized_sql.respond_to?(:ast)
 
-          records = if connection.instance_variable_get(:@query_cache_enabled)
-                      query_cache = connection.instance_variable_get(:@query_cache)
-                      query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sanitized_sql, binds)
+          records = if connection.query_cache_enabled
+                      connection.query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sanitized_sql, binds)
                     elsif connection.open_transactions > RC_TRANSACTIONS_THRESHOLD
                       connection.send(:select, sanitized_sql, "#{name} Load", binds)
                     else

--- a/lib/record_cache/datastore/active_record_31.rb
+++ b/lib/record_cache/datastore/active_record_31.rb
@@ -38,7 +38,7 @@ module RecordCache
           records = if connection.query_cache_enabled
                       connection.query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sanitized_sql, binds)
                     elsif connection.open_transactions > RC_TRANSACTIONS_THRESHOLD
-                      connection.send(:select, sanitized_sql, "#{name} Load", binds)
+                      connection.select_all(sanitized_sql, "#{name} Load", binds)
                     else
                       try_record_cache(arel, sanitized_sql, binds)
                     end
@@ -49,7 +49,7 @@ module RecordCache
         def try_record_cache(arel, sql, binds)
           query = arel && arel.respond_to?(:ast) ? RecordCache::Arel::QueryVisitor.new(binds).accept(arel.ast) : nil
           record_cache.fetch(query) do
-            connection.send(:select, sql, "#{name} Load", binds)
+            connection.select_all(sql, "#{name} Load", binds)
           end
         end
 

--- a/lib/record_cache/datastore/active_record_32.rb
+++ b/lib/record_cache/datastore/active_record_32.rb
@@ -38,7 +38,7 @@ module RecordCache
           records = if connection.query_cache_enabled
                       connection.query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sanitized_sql, binds)
                     elsif connection.open_transactions > RC_TRANSACTIONS_THRESHOLD
-                      connection.send(:select, sanitized_sql, "#{name} Load", binds)
+                      connection.select_all(sanitized_sql, "#{name} Load", binds)
                     else
                       try_record_cache(arel, sanitized_sql, binds)
                     end
@@ -50,7 +50,7 @@ module RecordCache
         def try_record_cache(arel, sql, binds)
           query = arel && arel.respond_to?(:ast) ? RecordCache::Arel::QueryVisitor.new(binds).accept(arel.ast) : nil
           record_cache.fetch(query) do
-            connection.send(:select, sql, "#{name} Load", binds)
+            connection.select_all(sql, "#{name} Load", binds)
           end
         end
 

--- a/lib/record_cache/datastore/active_record_32.rb
+++ b/lib/record_cache/datastore/active_record_32.rb
@@ -36,8 +36,7 @@ module RecordCache
           sanitized_sql = connection.to_sql(sanitized_sql, binds.dup) if sanitized_sql.respond_to?(:ast)
 
           records = if connection.query_cache_enabled
-                      query_cache = connection.instance_variable_get(:@query_cache)
-                      query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sanitized_sql, binds)
+                      connection.query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sanitized_sql, binds)
                     elsif connection.open_transactions > RC_TRANSACTIONS_THRESHOLD
                       connection.send(:select, sanitized_sql, "#{name} Load", binds)
                     else

--- a/lib/record_cache/datastore/active_record_40.rb
+++ b/lib/record_cache/datastore/active_record_40.rb
@@ -36,8 +36,7 @@ module RecordCache
           sanitized_sql = connection.to_sql(sanitized_sql, binds) if sanitized_sql.respond_to?(:ast)
 
           records = if connection.query_cache_enabled
-                      query_cache = connection.instance_variable_get(:@query_cache)
-                      query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sql, binds)
+                      connection.query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sql, binds)
 
                     elsif connection.open_transactions > RC_TRANSACTIONS_THRESHOLD
                       find_by_sql_without_record_cache(sql, binds)

--- a/lib/record_cache/datastore/active_record_41.rb
+++ b/lib/record_cache/datastore/active_record_41.rb
@@ -36,8 +36,7 @@ module RecordCache
           sanitized_sql = connection.to_sql(sanitized_sql, binds) if sanitized_sql.respond_to?(:ast)
 
           records = if connection.query_cache_enabled
-                      query_cache = connection.instance_variable_get(:@query_cache)
-                      query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sql, binds)
+                      connection.query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sql, binds)
 
                     elsif connection.open_transactions > RC_TRANSACTIONS_THRESHOLD
                       find_by_sql_without_record_cache(sql, binds)


### PR DESCRIPTION
This fixes 2 issues:

##### private `.select`

In Rails 3.X, the current code uses the protected method `ActiveRecord::ConnectionAdapters::DatabaseStatements#select` to dispatch actual queries.

This wreaks havoc if the underlying connection doesn't respond to `#select` itself, which is common with gems that wrap it (and only delegate public methods) — gems that pool, proxy, measure, shard, or replicate; e.g. [octopus](https://github.com/thiagopradi/octopus) or [autoreplica](https://github.com/WeTransfer/activerecord_autoreplica).

This fixes the issue by using the public and functionally equivalent `#select_all` method.

##### query cache accessors

In all supported versions of ActiveRecord, both query_cache_enabled and query_cache are public accessors.

Using those in place of instance_variable_get means we can support cases where the connection is wrapped in a delegator one way or other (plus instance_variable_get is a little unsightly ^__^)
