### PR TITLE
Uses public methods for query cache access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,5 @@ gemfile:
   - gemfiles/rails_40.gemfile
   - gemfiles/rails_41.gemfile
 
+before_install: 'gem install bundler'
 script: 'bundle exec rake'

--- a/lib/record_cache/datastore/active_record_30.rb
+++ b/lib/record_cache/datastore/active_record_30.rb
@@ -32,9 +32,8 @@ module RecordCache
           arel = sql.instance_variable_get(:@arel)
           sanitized_sql = sanitize_sql(sql)
 
-          records = if connection.instance_variable_get(:@query_cache_enabled)
-                      query_cache = connection.instance_variable_get(:@query_cache)
-                      query_cache["rc/#{sanitized_sql}"] ||= try_record_cache(sanitized_sql, arel)
+          records = if connection.query_cache_enabled
+                      connection.query_cache["rc/#{sanitized_sql}"] ||= try_record_cache(sanitized_sql, arel)
                     elsif connection.open_transactions > RC_TRANSACTIONS_THRESHOLD
                       connection.send(:select, sanitized_sql, "#{name} Load")
                     else

--- a/lib/record_cache/datastore/active_record_31.rb
+++ b/lib/record_cache/datastore/active_record_31.rb
@@ -35,9 +35,8 @@ module RecordCache
           sanitized_sql = sanitize_sql(sql)
           sanitized_sql = connection.visitor.accept(sanitized_sql.ast) if sanitized_sql.respond_to?(:ast)
 
-          records = if connection.instance_variable_get(:@query_cache_enabled)
-                      query_cache = connection.instance_variable_get(:@query_cache)
-                      query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sanitized_sql, binds)
+          records = if connection.query_cache_enabled
+                      connection.query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sanitized_sql, binds)
                     elsif connection.open_transactions > RC_TRANSACTIONS_THRESHOLD
                       connection.send(:select, sanitized_sql, "#{name} Load", binds)
                     else

--- a/lib/record_cache/datastore/active_record_32.rb
+++ b/lib/record_cache/datastore/active_record_32.rb
@@ -36,8 +36,7 @@ module RecordCache
           sanitized_sql = connection.to_sql(sanitized_sql, binds.dup) if sanitized_sql.respond_to?(:ast)
 
           records = if connection.query_cache_enabled
-                      query_cache = connection.instance_variable_get(:@query_cache)
-                      query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sanitized_sql, binds)
+                      connection.query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sanitized_sql, binds)
                     elsif connection.open_transactions > RC_TRANSACTIONS_THRESHOLD
                       connection.send(:select, sanitized_sql, "#{name} Load", binds)
                     else

--- a/lib/record_cache/datastore/active_record_40.rb
+++ b/lib/record_cache/datastore/active_record_40.rb
@@ -36,8 +36,7 @@ module RecordCache
           sanitized_sql = connection.to_sql(sanitized_sql, binds) if sanitized_sql.respond_to?(:ast)
 
           records = if connection.query_cache_enabled
-                      query_cache = connection.instance_variable_get(:@query_cache)
-                      query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sql, binds)
+                      connection.query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sql, binds)
 
                     elsif connection.open_transactions > RC_TRANSACTIONS_THRESHOLD
                       find_by_sql_without_record_cache(sql, binds)

--- a/lib/record_cache/datastore/active_record_41.rb
+++ b/lib/record_cache/datastore/active_record_41.rb
@@ -36,8 +36,7 @@ module RecordCache
           sanitized_sql = connection.to_sql(sanitized_sql, binds) if sanitized_sql.respond_to?(:ast)
 
           records = if connection.query_cache_enabled
-                      query_cache = connection.instance_variable_get(:@query_cache)
-                      query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sql, binds)
+                      connection.query_cache["rc/#{sanitized_sql}"][binds] ||= try_record_cache(arel, sql, binds)
 
                     elsif connection.open_transactions > RC_TRANSACTIONS_THRESHOLD
                       find_by_sql_without_record_cache(sql, binds)


### PR DESCRIPTION
A follow-up to #47.
In all supported versions of ActiveRecord, both `query_cache_enabled` and `query_cache` are public accessors.

Using those in place of `instance_variable_get` means we can support cases where the connection is wrapped in a delegator one way or other (plus `instance_variable_get` is a little unsightly ^__^)