### PR TITLE
Fixes bad parameters to version store

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
       activerecord (>= 3.2)
     thor (0.19.1)
     thread_safe (0.3.4)
+    timecop (0.8.0)
     tzinfo (0.3.42)
 
 PLATFORMS
@@ -118,3 +119,7 @@ DEPENDENCIES
   simplecov
   sqlite3
   test_after_commit
+  timecop
+
+BUNDLED WITH
+   1.11.2

--- a/gemfiles/rails_30.gemfile.lock
+++ b/gemfiles/rails_30.gemfile.lock
@@ -55,7 +55,7 @@ GEM
       treetop (~> 1.4.8)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mysql2 (0.4.1)
+    mysql2 (0.4.3)
     polyglot (0.3.5)
     pry (0.10.2)
       coderay (~> 1.1.0)

--- a/gemfiles/rails_30.gemfile.lock
+++ b/gemfiles/rails_30.gemfile.lock
@@ -105,6 +105,7 @@ GEM
     sqlite3 (1.3.10)
     test_after_commit (0.2.3)
     thor (0.14.6)
+    timecop (0.8.0)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -127,3 +128,7 @@ DEPENDENCIES
   simplecov
   sqlite3
   test_after_commit
+  timecop
+
+BUNDLED WITH
+   1.10.6

--- a/gemfiles/rails_31.gemfile.lock
+++ b/gemfiles/rails_31.gemfile.lock
@@ -116,6 +116,7 @@ GEM
     test_after_commit (0.2.3)
     thor (0.14.6)
     tilt (1.4.1)
+    timecop (0.8.0)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -138,3 +139,7 @@ DEPENDENCIES
   simplecov
   sqlite3
   test_after_commit
+  timecop
+
+BUNDLED WITH
+   1.10.6

--- a/gemfiles/rails_31.gemfile.lock
+++ b/gemfiles/rails_31.gemfile.lock
@@ -56,7 +56,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     multi_json (1.11.2)
-    mysql2 (0.4.1)
+    mysql2 (0.4.3)
     polyglot (0.3.5)
     pry (0.10.2)
       coderay (~> 1.1.0)

--- a/gemfiles/rails_32.gemfile.lock
+++ b/gemfiles/rails_32.gemfile.lock
@@ -55,7 +55,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     multi_json (1.11.2)
-    mysql2 (0.4.1)
+    mysql2 (0.4.3)
     polyglot (0.3.5)
     pry (0.10.2)
       coderay (~> 1.1.0)

--- a/gemfiles/rails_32.gemfile.lock
+++ b/gemfiles/rails_32.gemfile.lock
@@ -115,6 +115,7 @@ GEM
       activerecord (>= 3.2)
     thor (0.19.1)
     tilt (1.4.1)
+    timecop (0.8.0)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -137,3 +138,7 @@ DEPENDENCIES
   simplecov
   sqlite3
   test_after_commit
+  timecop
+
+BUNDLED WITH
+   1.10.6

--- a/gemfiles/rails_40.gemfile.lock
+++ b/gemfiles/rails_40.gemfile.lock
@@ -50,7 +50,7 @@ GEM
     mime-types (2.6.2)
     minitest (4.7.5)
     multi_json (1.11.2)
-    mysql2 (0.4.1)
+    mysql2 (0.4.3)
     pry (0.10.2)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)

--- a/gemfiles/rails_40.gemfile.lock
+++ b/gemfiles/rails_40.gemfile.lock
@@ -102,6 +102,7 @@ GEM
       activerecord (>= 3.2)
     thor (0.19.1)
     thread_safe (0.3.5)
+    timecop (0.8.0)
     tzinfo (0.3.45)
 
 PLATFORMS
@@ -121,3 +122,7 @@ DEPENDENCIES
   simplecov
   sqlite3
   test_after_commit
+  timecop
+
+BUNDLED WITH
+   1.10.6

--- a/gemfiles/rails_41.gemfile.lock
+++ b/gemfiles/rails_41.gemfile.lock
@@ -105,6 +105,7 @@ GEM
       activerecord (>= 3.2)
     thor (0.19.1)
     thread_safe (0.3.5)
+    timecop (0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -125,3 +126,7 @@ DEPENDENCIES
   simplecov
   sqlite3
   test_after_commit
+  timecop
+
+BUNDLED WITH
+   1.10.6

--- a/gemfiles/rails_41.gemfile.lock
+++ b/gemfiles/rails_41.gemfile.lock
@@ -51,7 +51,7 @@ GEM
     method_source (0.8.2)
     mime-types (2.6.2)
     minitest (5.8.1)
-    mysql2 (0.4.1)
+    mysql2 (0.4.3)
     pry (0.10.2)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)

--- a/lib/record_cache/strategy/index_cache.rb
+++ b/lib/record_cache/strategy/index_cache.rb
@@ -103,7 +103,7 @@ module RecordCache
         # retrieve local version and increment version store
         key = cache_key(value)
         old_version = version_store.current(key)
-        new_version = version_store.renew(key, version_opts)
+        new_version = version_store.renew(key, true, version_opts)
         # try to update the ids list based on the last version
         ids = fetch_ids_from_cache(versioned_key(key, old_version))
         if ids

--- a/record-cache.gemspec
+++ b/record-cache.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'test_after_commit'
+  s.add_development_dependency 'timecop'
 
 end

--- a/spec/lib/strategy/index_cache_spec.rb
+++ b/spec/lib/strategy/index_cache_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'timecop'
 
 RSpec.describe RecordCache::Strategy::IndexCache do
 
@@ -251,6 +252,14 @@ RSpec.describe RecordCache::Strategy::IndexCache do
       expect(address.location[:dms_lat]).to eq(%(27\u00B0 10' 30.0540" N))
       address.name = 'updated name'
       address.save!
+    end
+
+    it "should honor version store TTL" do
+      Apple.record_cache[:store_id].invalidate(1)
+      expect(RecordCache::Base.version_store.store.read('rc/apl/1')).not_to be_nil
+      Timecop.travel(1.hour.from_now) do
+        expect(RecordCache::Base.version_store.store.read('rc/apl/1')).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
The index strategy passes bad parameters to the version cache when invalidating, which unfortunately succeeded silently ... but resulted in invalidated version entries to never have a TTL set.
This fixes it.

The test isn't particularly elegant, but does cover the issue.